### PR TITLE
Unify mnemonics for ops with carry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ These are the supported opcodes:
 | 06     | JMPNEQ    | Jump if not equal                                    | 16-bit memory address                  |
 | 07     | JMPLT     | Jump if less than                                    | 16-bit memory address                  |
 | 08     | ADDMEM    | Arithmetic addition: ACC += *addr                    | 16-bit memory address                  |
-| 09     | SUBMEM    | Arithmetic addition with carry: ACC += *addr + C     | 16-bit memory address                  |
+| 09     | ADDCMEM   | Arithmetic addition with carry: ACC += *addr + C     | 16-bit memory address                  |
 | 0a     | SUBMEM    | Arithmetic subtraction: ACC -= *addr                 | 16-bit memory address                  |
-| 0b     | SUBBMEM   | Arithmetic subtraction with borrow: ACC -= *addr - C | 16-bit memory address                  |
+| 0b     | SUBCMEM   | Arithmetic subtraction with borrow: ACC -= *addr - C | 16-bit memory address                  |
 | 0c     | COM       | Complement: ACC = ~ACC                               | ignored                                |
 | 0d     | WRITE     | Write ACC to terminal                                | ignored                                |
 | 0e     | TERMINATE | Halt CPU                                             | ignored                                |
@@ -57,7 +57,7 @@ The main memory is fairly similar:
     (`!MWRITE` = read, `MWRITE` = write)
   - On a positive edge on `MCLK` if `!MWRITE`, data from `ADDR` is read into
     `DATA`.  On a positive edge on `MCLK` if `MWRITE`, `DATA` is stored at
-    address `ADDR`. 
+    address `ADDR`.
 
 ## Theory of operation
 Each instruction is executed in 23 clock cycles. If particular stages are not

--- a/educpu-as
+++ b/educpu-as
@@ -38,7 +38,7 @@ class Opcodes(enum.IntEnum):
 	addmem = 0x8
 	addcmem = 0x9
 	submem = 0xa
-	subbmem = 0xb
+	subcmem = 0xb
 	com = 0xc
 	write = 0xd
 	terminate = 0xe

--- a/educpu.circ
+++ b/educpu.circ
@@ -2336,7 +2336,7 @@
     <comp lib="0" loc="(980,1660)" name="Pin">
       <a name="appearance" val="NewPins"/>
       <a name="facing" val="west"/>
-      <a name="label" val="SUBBMEM"/>
+      <a name="label" val="SUBCMEM"/>
       <a name="output" val="true"/>
     </comp>
     <comp lib="0" loc="(980,1740)" name="Pin">
@@ -2485,7 +2485,7 @@
       <rect height="3" stroke="none" width="10" x="50" y="119"/>
       <text dominant-baseline="alphabetic" fill="#404040" font-family="Courier 10 Pitch" font-size="12" text-anchor="start" x="65" y="124">SUB</text>
       <rect height="3" stroke="none" width="10" x="50" y="139"/>
-      <text dominant-baseline="alphabetic" fill="#404040" font-family="Courier 10 Pitch" font-size="12" text-anchor="start" x="65" y="144">SUBB</text>
+      <text dominant-baseline="alphabetic" fill="#404040" font-family="Courier 10 Pitch" font-size="12" text-anchor="start" x="65" y="144">SUBC</text>
       <rect height="3" stroke="none" width="10" x="50" y="159"/>
       <text dominant-baseline="alphabetic" fill="#404040" font-family="Courier 10 Pitch" font-size="12" text-anchor="start" x="65" y="164">COM</text>
       <rect height="4" stroke="none" width="10" x="50" y="178"/>
@@ -2549,7 +2549,7 @@
     </comp>
     <comp lib="0" loc="(200,520)" name="Pin">
       <a name="appearance" val="NewPins"/>
-      <a name="label" val="SUBB"/>
+      <a name="label" val="SUBC"/>
     </comp>
     <comp lib="0" loc="(200,560)" name="Pin">
       <a name="appearance" val="NewPins"/>


### PR DESCRIPTION
There was a slight inconsistency in the documentation/source w.r.t. the opcodes for addition/subtraction with carry.